### PR TITLE
release 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Blast Turbine Changelog
 
+## 1.1.4
+
+### Fixes
+
+- #9 If class exists and is not part of container, `League\Container\Container::has` returns now false.
+
 ## 1.1.3
 
 ### Altered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- #9 If class exists and is not part of container, `League\Container\Container::has` returns now false.
+- [\#9](../../issues/9) If class exists and is not part of container, `League\Container\Container::has` returns now false.
 
 ## 1.1.3
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -92,7 +92,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function __construct($configuration = [])
     {
-        if (is_bool($configuration)) {
+        if ( is_bool($configuration) ) {
             $this->setConfig(self::KEY_ERROR, $configuration);
         } elseif (
             is_array($configuration) ||
@@ -121,7 +121,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
     {
 
         $configurator = $this->getConfigurator();
-        if (is_array($key) || $key instanceof \Traversable || $key instanceof \ArrayAccess) {
+        if ( is_array($key) || $key instanceof \Traversable || $key instanceof \ArrayAccess ) {
             $iter = new \ArrayIterator($key);
             while ($iter->valid()) {
                 $this->setConfig($iter->key(), $iter->current());
@@ -147,7 +147,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
     {
 
         $configurator = $this->getConfigurator();
-        if ($key === null) {
+        if ( $key === null ) {
             return $configurator;
         }
 
@@ -165,7 +165,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function hasConfig($key)
     {
-        if (null === $key) {
+        if ( null === $key ) {
             return false;
         }
 
@@ -188,9 +188,10 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getConfigurator()
     {
-        if (!$this->getContainer()->has(\ArrayAccess::class)) {
+        if ( ! $this->getContainer()->has(\ArrayAccess::class) ) {
             $this->getContainer()->share(\ArrayAccess::class, \ArrayObject::class);
         }
+
         return $this->getContainer()->get(\ArrayAccess::class);
     }
 
@@ -202,11 +203,6 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function setContainer(ContainerInterface $container)
     {
-        if ($container instanceof Container) {
-            $container->delegate(
-                new ReflectionContainer
-            );
-        }
         $application = $this;
         $container->share(ApplicationInterface::class, $application);
         $container->share(\Interop\Container\ContainerInterface::class, $container);
@@ -223,7 +219,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getContainer()
     {
-        if (!isset($this->container)) {
+        if ( ! isset($this->container) ) {
             $this->setContainer(new Container);
         }
 
@@ -237,7 +233,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getEmitter()
     {
-        if (!$this->getContainer()->has(EmitterInterface::class)) {
+        if ( ! $this->getContainer()->has(EmitterInterface::class) ) {
             $this->getContainer()->share(EmitterInterface::class, new Emitter());
         }
 
@@ -249,16 +245,18 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getErrorHandler()
     {
-        if (!$this->getContainer()->has(Run::class)) {
+        if ( ! $this->getContainer()->has(Run::class) ) {
             $errorHandler = new Run();
             $errorHandler->pushHandler($this->getErrorResponseHandler());
             $errorHandler->pushHandler(function ($exception) {
                 $this->emit(static::EVENT_RUNTIME_ERROR, [$exception]);
+
                 return Handler::DONE;
             });
             $errorHandler->register();
             $this->getContainer()->share(Run::class, $errorHandler);
         }
+
         return $this->validateContract($this->getContainer()->get(Run::class), Run::class);
     }
 
@@ -269,10 +267,10 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getErrorResponseHandler()
     {
-        if (!$this->getContainer()->has(HandlerInterface::class)) {
-            if ($this->isCli()) {
+        if ( ! $this->getContainer()->has(HandlerInterface::class) ) {
+            if ( $this->isCli() ) {
                 $class = PlainTextHandler::class;
-            } elseif ($this->isAjaxRequest()) {
+            } elseif ( $this->isAjaxRequest() ) {
                 $class = JsonResponseHandler::class;
             } else {
                 $class = PrettyPageHandler::class;
@@ -301,11 +299,11 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getLogger($name = 'default')
     {
-        if (isset($this->loggers[$name])) {
+        if ( isset($this->loggers[$name]) ) {
             return $this->loggers[$name];
         }
 
-        if (!$this->getContainer()->has(LoggerInterface::class)) {
+        if ( ! $this->getContainer()->has(LoggerInterface::class) ) {
             $this->getContainer()->add(LoggerInterface::class, Logger::class);
         }
 
@@ -321,9 +319,12 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getRouter()
     {
-        if (!isset($this->router)) {
-            $this->router = (new RouteCollection($this->getContainer()));
+        if ( ! isset($this->router) ) {
+            $container = clone $this->getContainer();
+            $container->delegate(new ReflectionContainer);
+            $this->router = (new RouteCollection($container));
         }
+
         return $this->validateContract($this->router, RouteCollection::class);
     }
 
@@ -334,11 +335,12 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getRequest()
     {
-        if (!$this->getContainer()->has(ServerRequestInterface::class)) {
+        if ( ! $this->getContainer()->has(ServerRequestInterface::class) ) {
             $this->getContainer()->share(ServerRequestInterface::class, ServerRequestFactory::fromGlobals());
         }
 
-        return $this->validateContract($this->getContainer()->get(ServerRequestInterface::class), ServerRequestInterface::class);
+        return $this->validateContract($this->getContainer()->get(ServerRequestInterface::class),
+            ServerRequestInterface::class);
     }
 
     /**
@@ -350,23 +352,23 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
     public function getResponse($content = '')
     {
         //transform content by environment and request type
-        if ($this->isAjaxRequest()) {
-            if ($content instanceof Response\JsonResponse) {
+        if ( $this->isAjaxRequest() ) {
+            if ( $content instanceof Response\JsonResponse ) {
                 $content = json_decode($content->getBody());
-            } elseif (!is_array($content)) {
+            } elseif ( ! is_array($content) ) {
                 $content = [$content];
             }
         } else {
-            if (is_array($content)) {
+            if ( is_array($content) ) {
                 $content = implode('', $content);
-            } elseif ($content instanceof ResponseInterface) {
+            } elseif ( $content instanceof ResponseInterface ) {
                 $content = $content->getBody()->__toString();
             }
         }
-        if (!$this->getContainer()->has(ResponseInterface::class)) {
-            if ($this->isCli()) {
+        if ( ! $this->getContainer()->has(ResponseInterface::class) ) {
+            if ( $this->isCli() ) {
                 $class = Response\TextResponse::class;
-            } elseif ($this->isAjaxRequest()) {
+            } elseif ( $this->isAjaxRequest() ) {
                 $class = Response\JsonResponse::class;
 
             } else {
@@ -375,7 +377,8 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
             $this->getContainer()->add(ResponseInterface::class, $class);
         }
 
-        return $this->validateContract($this->getContainer()->get(ResponseInterface::class, [$content]), ResponseInterface::class);
+        return $this->validateContract($this->getContainer()->get(ResponseInterface::class, [$content]),
+            ResponseInterface::class);
     }
 
 
@@ -386,11 +389,12 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function getResponseEmitter()
     {
-        if (!$this->getContainer()->has(Response\EmitterInterface::class)) {
+        if ( ! $this->getContainer()->has(Response\EmitterInterface::class) ) {
             $this->getContainer()->share(Response\EmitterInterface::class, new Response\SapiEmitter());
         }
 
-        return $this->validateContract($this->getContainer()->get(Response\EmitterInterface::class), Response\EmitterInterface::class);
+        return $this->validateContract($this->getContainer()->get(Response\EmitterInterface::class),
+            Response\EmitterInterface::class);
     }
 
     /*******************************************
@@ -440,7 +444,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function isHttpRequest()
     {
-        return !$this->isCli();
+        return ! $this->isCli();
     }
 
     /**
@@ -616,24 +620,25 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
         $validateObject = function ($object) {
             //does need trigger when calling *_exists with object
             $condition = is_string($object) ? class_exists($object) || interface_exists($object) : is_object($object);
-            if (false === $condition) {
+            if ( false === $condition ) {
                 $this->throwException(new \InvalidArgumentException('Class not exists ' . $object));
             }
         };
 
         $convertClassToString = function ($object) {
-            if (is_object($object)) {
+            if ( is_object($object) ) {
                 $object = get_class($object);
             }
+
             return is_string($object) ? $object : false;
         };
 
         $validateObject($class);
         $validateObject($contract);
 
-        if (!($class instanceof $contract)) {
+        if ( ! ($class instanceof $contract) ) {
 
-            if (is_object($class)) {
+            if ( is_object($class) ) {
                 $class = get_class($class);
             }
             $this->throwException(new \LogicException($convertClassToString($class) . ' needs to be an instance of ' . $convertClassToString($contract)));
@@ -660,13 +665,16 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      *
      * @throws \Throwable
      */
-    public function handle(ServerRequestInterface $request, ResponseInterface $response = null, $catch = self::DEFAULT_ERROR_CATCH)
-    {
+    public function handle(
+        ServerRequestInterface $request,
+        ResponseInterface $response = null,
+        $catch = self::DEFAULT_ERROR_CATCH
+    ) {
 
         // Passes the request to the container
         $this->getContainer()->share(ServerRequestInterface::class, $request);
 
-        if ($response === null) {
+        if ( $response === null ) {
             $response = $this->getResponse();
         }
 
@@ -715,8 +723,12 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      *
      * @throws string
      */
-    public function handleError($exception, ServerRequestInterface $request, ResponseInterface $response, $catch = self::DEFAULT_ERROR_CATCH)
-    {
+    public function handleError(
+        $exception,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        $catch = self::DEFAULT_ERROR_CATCH
+    ) {
         $exception = $this->decorateException($exception);
         $errorHandler = $this->getErrorHandler();
 
@@ -748,11 +760,11 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     public function run(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
-        if ($request === null) {
+        if ( $request === null ) {
             $request = $this->getRequest();
         }
 
-        if ($response === null) {
+        if ( $response === null ) {
             $response = $this->getResponse();
         }
 
@@ -760,7 +772,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
 
         $this->emitResponse($request, $response);
 
-        if ($this->canTerminate()) {
+        if ( $this->canTerminate() ) {
             $this->terminate($request, $response);
         }
 
@@ -817,32 +829,32 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
         // close response stream berfore terminating output buffer
         // and only if response is an instance of
         // \Psr\Http\ResponseInterface
-        if ($response instanceof ResponseInterface) {
+        if ( $response instanceof ResponseInterface ) {
             $body = $response->getBody();
-            if ($body->isReadable()) {
+            if ( $body->isReadable() ) {
                 $body->close();
             }
         }
 
         // Command line output buffering is disabled in cli by default
-        if ($this->isCli()) {
+        if ( $this->isCli() ) {
             return;
         }
 
         // $level needs to be a numeric value
-        if (!is_numeric($level)) {
+        if ( ! is_numeric($level) ) {
             $level = 0;
         }
 
         // force type casting to an integer value
-        if (!is_int($level)) {
+        if ( ! is_int($level) ) {
             $level = (int)$level;
         }
 
         // avoid infinite loop on clearing
         // output buffer by set level to 0
         // if $level is smaller
-        if (-1 > $level) {
+        if ( -1 > $level ) {
             $level = 0;
         }
 
@@ -858,13 +870,13 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
     public function cleanUp()
     {
         // try to enable garbage collection
-        if (!gc_enabled()) {
+        if ( ! gc_enabled() ) {
             @gc_enable();
         }
 
         // collect garbage only if garbage
         // collection is enabled
-        if (gc_enabled()) {
+        if ( gc_enabled() ) {
             gc_collect_cycles();
         }
     }
@@ -878,23 +890,24 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
     private function decorateException($error)
     {
 
-        if (is_callable($error)) {
+        if ( is_callable($error) ) {
             $error = $this->getContainer()->call($error, [$this->getRequest(), $this->getResponse()]);
         }
 
-        if (is_object($error) && !($error instanceof \Exception)) {
-            $error = method_exists($error, '__toString') ? $error->__toString() : 'Error with object ' . get_class($error);
+        if ( is_object($error) && ! ($error instanceof \Exception) ) {
+            $error = method_exists($error,
+                '__toString') ? $error->__toString() : 'Error with object ' . get_class($error);
         }
 
-        if (is_resource($error)) {
+        if ( is_resource($error) ) {
             $error = 'Error with resource type ' . get_resource_type($error);
         }
 
-        if (is_array($error)) {
+        if ( is_array($error) ) {
             $error = implode("\n", $error);
         }
 
-        if (!($error instanceof \Exception)) {
+        if ( ! ($error instanceof \Exception) ) {
             $error = new \Exception(is_scalar($error) ? $error : 'Error with ' . gettype($error));
         }
 
@@ -912,7 +925,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     private function determineErrorMessage($exception, $errorHandler)
     {
-        if (false === $this->getConfig(self::KEY_ERROR, static::DEFAULT_ERROR)) {
+        if ( false === $this->getConfig(self::KEY_ERROR, static::DEFAULT_ERROR) ) {
             $message = $exception->getMessage();
         } else {
             $errorHandler->allowQuit($this->error);
@@ -922,6 +935,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
             $errorHandler->$method($exception);
             $message = ob_get_clean();
         }
+
         return $message;
     }
 
@@ -934,18 +948,22 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
-    private function determineErrorResponse($exception, $message, ResponseInterface $response, ServerRequestInterface $request)
-    {
+    private function determineErrorResponse(
+        $exception,
+        $message,
+        ResponseInterface $response,
+        ServerRequestInterface $request
+    ) {
         $errorResponse = $this->getResponse();
         $this->emit(self::EVENT_LIFECYCLE_ERROR, $exception, $request, $errorResponse, $response);
         $this->error = true;
 
-        if (!$errorResponse->getBody()->isWritable()) {
+        if ( ! $errorResponse->getBody()->isWritable() ) {
             return $errorResponse;
         }
 
         $content = $errorResponse->getBody()->__toString();
-        if (empty($content)) {
+        if ( empty($content) ) {
             $errorResponse->getBody()->write($message);
         }
 
@@ -960,7 +978,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     private function validateConfigKey($key)
     {
-        if (!is_scalar($key)) {
+        if ( ! is_scalar($key) ) {
             $this->throwException(new \InvalidArgumentException('Key needs to be a valid scalar!'));
         }
     }
@@ -974,7 +992,7 @@ class Application implements ApplicationInterface, ContainerAwareInterface, List
      */
     private function bindClosureToInstance($closure)
     {
-        if ($closure instanceof \Closure) {
+        if ( $closure instanceof \Closure ) {
             \Closure::bind($closure, $this, get_class($this));
         }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -32,6 +32,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $app->getConfig('bar'));
     }
 
+
+
     public function testConfigurationFromArrayObject(){
         $app = new Application(new \ArrayObject(['foo' => 'bar']));
         $this->assertInstanceOf(\ArrayAccess::class,$app->getConfig());
@@ -297,5 +299,12 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($app->isHttpRequest());
         $this->assertFalse($app->isAjaxRequest());
         $this->assertTrue($app->isCli());
+    }
+
+    public function testContainerHasNotClass()
+    {
+        $app = new Application();
+
+        $this->assertFalse($app->getContainer()->has(\SplMaxHeap::class), 'Should not assert true, when class exists but is not part of container');
     }
 }


### PR DESCRIPTION
## 1.1.4
### Fixes
- [#9](../../issues/9) If class exists and is not part of container, `League\Container\Container::has` returns now false.
